### PR TITLE
Handle function references (arity) properly

### DIFF
--- a/lib/exavier.ex
+++ b/lib/exavier.ex
@@ -114,6 +114,18 @@ defmodule Exavier do
     {mutated_lines_body_rest, [{operator, mutated_body} | mutated_rest]}
   end
 
+  def mutate_all({:&, meta, args} = _ast, mutator, lines_to_mutate, already_mutated_lines) do
+    current_line = meta[:line]
+    {mutated_lines, mutated_args} =
+      case Enum.member?(lines_to_mutate, current_line) do
+        true ->
+          mutate_all(args, mutator, List.delete(lines_to_mutate, current_line), [current_line | already_mutated_lines])
+        _ ->
+          mutate_all(args, mutator, lines_to_mutate, already_mutated_lines)
+        end
+    {mutated_lines, {:&, meta, mutated_args}}
+  end
+
   def mutate_all(
     {operator, meta, args} = ast, mutator, lines_to_mutate, already_mutated_lines
   ) do

--- a/test/fixtures/foo_bar.ex
+++ b/test/fixtures/foo_bar.ex
@@ -1,3 +1,11 @@
 defmodule FooBar do
   def sub(a, b), do: a - b
+
+  def list_sum(list) do
+    Enum.reduce(list, 0, &add/2)
+  end
+
+  def div(a, b) when b != 0, do: a / b
+
+  defp add(a, b), do: a + b
 end

--- a/test/foo_bar_test.exs
+++ b/test/foo_bar_test.exs
@@ -3,7 +3,15 @@ defmodule FooBarTest do
 
   @subject FooBar
 
-  test "when 0, 0" do
+  test "when 0, sub 0" do
     assert @subject.sub(0, 0) == 0
+  end
+
+  test "when [1, 2, 3], list_sum 6" do
+    assert @subject.list_sum([1, 2, 3]) == 6
+  end
+
+  test "when one number is negative" do
+    assert @subject.div(100, -20) == -5
   end
 end


### PR DESCRIPTION
Fixes this issue.
We now mutate :/ operator only in case when it's an arithmetic operator.